### PR TITLE
Enable transparent layers

### DIFF
--- a/src/leaflet.wms.js
+++ b/src/leaflet.wms.js
@@ -306,8 +306,8 @@ wms.Overlay = L.Layer.extend({
         'version': '1.1.1',
         'layers': '',
         'styles': '',
-        'format': 'image/jpeg',
-        'transparent': false
+        'format': 'image/png',
+        'transparent': true
     },
 
     'options': {


### PR DESCRIPTION
Changed the default format to .png, in order to enable transparent layers.